### PR TITLE
Use `ScoreToString` in custom summary meta file

### DIFF
--- a/src/tioj/submission.cpp
+++ b/src/tioj/submission.cpp
@@ -82,7 +82,7 @@ nlohmann::json SubmissionAndResult::SummaryMeta() const {
     const auto& td_result = result.td_results[i];
     testdata.push_back({
       {"verdict", VerdictToAbr(td_result.verdict)},
-      {"score", td_result.score},
+      {"score", ScoreToString(td_result.score)},
       {"time_us", td_result.time},
       {"vss_kib", td_result.vss},
       {"rss_kib", td_result.rss},


### PR DESCRIPTION
Without this, the per-testdata score in the metadata file would be `10^6` times bigger. Summary code should receive an `0~100` float score rather than internal used `0~10^8` integer.