### PR TITLE
added rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 WORKDIR /judge
 RUN apt update
-RUN apt install -y git g++ cmake ninja-build libseccomp-dev libnl-genl-3-dev libsqlite3-dev libz-dev libssl-dev ghc python2 python3 python3-numpy python3-pil libboost-all-dev libzstd-dev
+RUN apt install -y git g++ cmake ninja-build libseccomp-dev libnl-genl-3-dev libsqlite3-dev libz-dev libssl-dev ghc python2 python3 python3-numpy python3-pil libboost-all-dev libzstd-dev rustc
 
 COPY . ./
 

--- a/include/tioj/submission.h
+++ b/include/tioj/submission.h
@@ -56,7 +56,7 @@ enum class SummaryType {
   X(GCC_C_99, "c99") \
   X(GCC_C_11, "c11") \
   X(GCC_C_17, "c17") \
-  X(RUST, "rust") \
+  X(RUSTC_RUST_2021, "rust2021") \
   X(HASKELL, "haskell") \
   X(PYTHON2, "python2") \
   X(PYTHON3, "python3") \

--- a/include/tioj/submission.h
+++ b/include/tioj/submission.h
@@ -56,7 +56,7 @@ enum class SummaryType {
   X(GCC_C_99, "c99") \
   X(GCC_C_11, "c11") \
   X(GCC_C_17, "c17") \
-  X(RUSTC_RUST_2021, "rust2021") \
+  X(RUSTC_RUST_2021, "rust 2021") \
   X(HASKELL, "haskell") \
   X(PYTHON2, "python2") \
   X(PYTHON3, "python3") \

--- a/include/tioj/submission.h
+++ b/include/tioj/submission.h
@@ -56,6 +56,7 @@ enum class SummaryType {
   X(GCC_C_99, "c99") \
   X(GCC_C_11, "c11") \
   X(GCC_C_17, "c17") \
+  X(RUST, "rust") \
   X(HASKELL, "haskell") \
   X(PYTHON2, "python2") \
   X(PYTHON3, "python3") \

--- a/src/tioj/paths.cpp
+++ b/src/tioj/paths.cpp
@@ -32,6 +32,7 @@ inline std::string CodeExtension(Compiler lang) {
     case Compiler::GCC_C_99: [[fallthrough]];
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17: return ".c";
+    case Compiler::RUST: return ".rs";
     case Compiler::HASKELL: return ".hs";
     case Compiler::PYTHON2: [[fallthrough]];
     case Compiler::PYTHON3: return ".py";
@@ -51,6 +52,7 @@ inline std::string ProgramExtension(Compiler lang) {
     case Compiler::GCC_C_99: [[fallthrough]];
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17: return "";
+    case Compiler::RUST: return "";
     case Compiler::HASKELL: return "";
     case Compiler::PYTHON2: [[fallthrough]];
     case Compiler::PYTHON3: return ".pyc";
@@ -147,6 +149,8 @@ fs::perms ExecuteBoxProgramPerm(Compiler lang, bool strict) {
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17:
       return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711
+    case Compiler::RUST:
+      return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 755
     case Compiler::HASKELL:
       return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711
     case Compiler::PYTHON2: [[fallthrough]];

--- a/src/tioj/paths.cpp
+++ b/src/tioj/paths.cpp
@@ -150,7 +150,7 @@ fs::perms ExecuteBoxProgramPerm(Compiler lang, bool strict) {
     case Compiler::GCC_C_17:
       return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711
     case Compiler::RUST:
-      return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 755
+      return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711
     case Compiler::HASKELL:
       return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711
     case Compiler::PYTHON2: [[fallthrough]];

--- a/src/tioj/paths.cpp
+++ b/src/tioj/paths.cpp
@@ -32,7 +32,7 @@ inline std::string CodeExtension(Compiler lang) {
     case Compiler::GCC_C_99: [[fallthrough]];
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17: return ".c";
-    case Compiler::RUST: return ".rs";
+    case Compiler::RUSTC_RUST_2021: return ".rs";
     case Compiler::HASKELL: return ".hs";
     case Compiler::PYTHON2: [[fallthrough]];
     case Compiler::PYTHON3: return ".py";
@@ -52,7 +52,7 @@ inline std::string ProgramExtension(Compiler lang) {
     case Compiler::GCC_C_99: [[fallthrough]];
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17: return "";
-    case Compiler::RUST: return "";
+    case Compiler::RUSTC_RUST_2021: return "";
     case Compiler::HASKELL: return "";
     case Compiler::PYTHON2: [[fallthrough]];
     case Compiler::PYTHON3: return ".pyc";
@@ -149,7 +149,7 @@ fs::perms ExecuteBoxProgramPerm(Compiler lang, bool strict) {
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17:
       return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711
-    case Compiler::RUST:
+    case Compiler::RUSTC_RUST_2021:
       return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711
     case Compiler::HASKELL:
       return fs::perms::owner_all | fs::perms::group_exec | fs::perms::others_exec; // 711

--- a/src/tioj/tasks.cpp
+++ b/src/tioj/tasks.cpp
@@ -211,8 +211,9 @@ struct cjail_result RunExecute(const SubmissionAndResult& sub_and_result, const 
   opt.fsize = lim.output;
   if (opt.fsize == 0 || opt.fsize > kMaxOutput) opt.fsize = kMaxOutput;
   if (sub.sandbox_strict) {
-    if (lang == Compiler::PYTHON2 || lang == Compiler::PYTHON3) {
+    if (lang == Compiler::PYTHON2 || lang == Compiler::PYTHON3 || lang == Compiler::RUST) {
       // TODO: is it possible to run without /usr/bin and /bin? (maybe copy python executable to workdir)
+      // TODO: make rust static linking in strict mode
       opt.dirs = {"/usr", "/lib", "/lib64", "/etc/alternatives", "/bin"};
     }
     int fd_input = open(ExecuteBoxInput(id, subtask, stage, sub.sandbox_strict).c_str(), O_RDONLY);

--- a/src/tioj/tasks.cpp
+++ b/src/tioj/tasks.cpp
@@ -49,7 +49,7 @@ std::vector<std::string> ExecuteCommand(Compiler lang, const std::string& progra
     case Compiler::GCC_C_99: [[fallthrough]];
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17: [[fallthrough]];
-    case Compiler::RUST: [[fallthrough]];
+    case Compiler::RUSTC_RUST_2021: [[fallthrough]];
     case Compiler::HASKELL: return {program};
     case Compiler::PYTHON2: return {"/usr/bin/env", "python2", program};
     case Compiler::PYTHON3: return {"/usr/bin/env", "python3", program};
@@ -129,8 +129,8 @@ struct cjail_result RunCompile(const SubmissionAndResult& sub_and_result, const 
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17:
       opt.command = GccCompileCommand(lang, input, interlib, output, sub.sandbox_strict); break;
-    case Compiler::RUST:
-      opt.command = {"/usr/bin/env", "TMPDIR=.", "rustc", input, "-O", "-o", output}; break;
+    case Compiler::RUSTC_RUST_2021:
+      opt.command = {"/usr/bin/env", "TMPDIR=.", "rustc", input, "-O", "--edition", "2021", "-o", output}; break;
     case Compiler::HASKELL: {
       opt.command = {"/usr/bin/env", "ghc", "-w", "-O", "-tmpdir", ".", "-o", output, input};
       if (sub.sandbox_strict) {
@@ -211,7 +211,7 @@ struct cjail_result RunExecute(const SubmissionAndResult& sub_and_result, const 
   opt.fsize = lim.output;
   if (opt.fsize == 0 || opt.fsize > kMaxOutput) opt.fsize = kMaxOutput;
   if (sub.sandbox_strict) {
-    if (lang == Compiler::PYTHON2 || lang == Compiler::PYTHON3 || lang == Compiler::RUST) {
+    if (lang == Compiler::PYTHON2 || lang == Compiler::PYTHON3 || lang == Compiler::RUSTC_RUST_2021) {
       // TODO: is it possible to run without /usr/bin and /bin? (maybe copy python executable to workdir)
       // TODO: make rust static linking in strict mode
       opt.dirs = {"/usr", "/lib", "/lib64", "/etc/alternatives", "/bin"};

--- a/src/tioj/tasks.cpp
+++ b/src/tioj/tasks.cpp
@@ -130,7 +130,7 @@ struct cjail_result RunCompile(const SubmissionAndResult& sub_and_result, const 
     case Compiler::GCC_C_17:
       opt.command = GccCompileCommand(lang, input, interlib, output, sub.sandbox_strict); break;
     case Compiler::RUSTC_RUST_2021:
-      opt.command = {"/usr/bin/env", "TMPDIR=.", "rustc", input, "-O", "--edition", "2021", "-o", output}; break;
+      opt.command = {"/usr/bin/env", "TMPDIR=.", "rustc", input, "-O", "--edition=2021", "-o", output}; break;
     case Compiler::HASKELL: {
       opt.command = {"/usr/bin/env", "ghc", "-w", "-O", "-tmpdir", ".", "-o", output, input};
       if (sub.sandbox_strict) {

--- a/src/tioj/tasks.cpp
+++ b/src/tioj/tasks.cpp
@@ -49,6 +49,7 @@ std::vector<std::string> ExecuteCommand(Compiler lang, const std::string& progra
     case Compiler::GCC_C_99: [[fallthrough]];
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17: [[fallthrough]];
+    case Compiler::RUST: [[fallthrough]];
     case Compiler::HASKELL: return {program};
     case Compiler::PYTHON2: return {"/usr/bin/env", "python2", program};
     case Compiler::PYTHON3: return {"/usr/bin/env", "python3", program};
@@ -128,6 +129,8 @@ struct cjail_result RunCompile(const SubmissionAndResult& sub_and_result, const 
     case Compiler::GCC_C_11: [[fallthrough]];
     case Compiler::GCC_C_17:
       opt.command = GccCompileCommand(lang, input, interlib, output, sub.sandbox_strict); break;
+    case Compiler::RUST:
+      opt.command = {"/usr/bin/env", "TMPDIR=.", "rustc", input, "-O", "-o", output}; break;
     case Compiler::HASKELL: {
       opt.command = {"/usr/bin/env", "ghc", "-w", "-O", "-tmpdir", ".", "-o", output, input};
       if (sub.sandbox_strict) {

--- a/test/submission_test.cpp
+++ b/test/submission_test.cpp
@@ -53,12 +53,3 @@ int main(){ int a; scanf("%d",&a);printf("%d",a); })"},
     ParamName);
 
 // TODO: multiple submission rejudge
-/*
-struct SubParam {
-  int sub_id;
-  int parallel;
-  bool is_strict;
-  Compiler lang;
-  std::string code;
-};
-*/

--- a/test/submission_test.cpp
+++ b/test/submission_test.cpp
@@ -47,8 +47,8 @@ int main(){ int a; scanf("%d",&a);printf("%d",a); })"},
       (SubParam){3, 1, true, Compiler::PYTHON2, "print input()"},
       (SubParam){4, 1, false, Compiler::PYTHON3, "print(input())"},
       (SubParam){4, 4, true, Compiler::PYTHON3, "import sys; print(sys.stdin.read())"},
-      (SubParam){5, 1, false, Compiler::RUST, R"(use std::io::{self, Read}; let mut s = String::new(); let _ = io::stdin().read_to_string(&mut s); println!("{s}");)"},
-      (SubParam){5, 4, true, Compiler::RUST, R"(use std::io::{self, Read}; let mut s = String::new(); let _ = io::stdin().read_to_string(&mut s); println!("{s}");)"}
+      (SubParam){5, 1, false, Compiler::RUSTC_RUST_2021, R"(use std::io::{self, Read}; let mut s = String::new(); let _ = io::stdin().read_to_string(&mut s); println!("{s}");)"},
+      (SubParam){5, 4, true, Compiler::RUSTC_RUST_2021, R"(use std::io::{self, Read}; let mut s = String::new(); let _ = io::stdin().read_to_string(&mut s); println!("{s}");)"}
     ),
     ParamName);
 

--- a/test/submission_test.cpp
+++ b/test/submission_test.cpp
@@ -46,8 +46,19 @@ int main(){ int a; scanf("%d",&a);printf("%d",a); })"},
       (SubParam){3, 4, false, Compiler::PYTHON2, "print input()"},
       (SubParam){3, 1, true, Compiler::PYTHON2, "print input()"},
       (SubParam){4, 1, false, Compiler::PYTHON3, "print(input())"},
-      (SubParam){4, 4, true, Compiler::PYTHON3, "import sys; print(sys.stdin.read())"}
+      (SubParam){4, 4, true, Compiler::PYTHON3, "import sys; print(sys.stdin.read())"},
+      (SubParam){5, 1, false, Compiler::RUST, R"(use std::io::{self, Read}; let mut s = String::new(); let _ = io::stdin().read_to_string(&mut s); println!("{s}");)"},
+      (SubParam){5, 4, true, Compiler::RUST, R"(use std::io::{self, Read}; let mut s = String::new(); let _ = io::stdin().read_to_string(&mut s); println!("{s}");)"}
     ),
     ParamName);
 
 // TODO: multiple submission rejudge
+/*
+struct SubParam {
+  int sub_id;
+  int parallel;
+  bool is_strict;
+  Compiler lang;
+  std::string code;
+};
+*/


### PR DESCRIPTION
Added rust to tioj-judge.
The rust compile command is "TMP_DIR=. rustc {input_file} -O -o {output_file}", which TMP_DIR=. is needed since /tmp is not accessible from the sandbox.
Since only rustc is used, packages not in std cannot be used.
Strict mode uses the exact same flow as Python, since static linking in rust may take several extra steps and I may mess up the code more.
Tested in the docker environment with https://github.com/pingchungchang/tioj/tree/main, which adds rust to the compilers list in the front end.