### PR TITLE
Mount /var/lib/ghc instead of /var/lib in compile sandboxes

### DIFF
--- a/src/tioj/tasks.cpp
+++ b/src/tioj/tasks.cpp
@@ -181,10 +181,12 @@ struct cjail_result RunCompile(const SubmissionAndResult& sub_and_result, const 
   opt.rss = kMaxRSS;
   opt.proc_num = 10;
   opt.fsize = kMaxOutput;
-  opt.dirs = {"/usr", "/var/lib", "/lib", "/lib64", "/etc/alternatives", "/bin"};
+  opt.dirs = {"/usr", "/lib", "/lib64", "/etc/alternatives", "/bin"};
+  if (lang == Compiler::HASKELL) {
+    opt.dirs.push_back("/var/lib/ghc");
+  }
   opt.FilterDirs();
   return SandboxExec(opt);
-  // we don't need to close the opened files because the process is about to terminate
 }
 
 // TODO FEATURE(io-interactive): fork & run multiple cjails and merge them into one cjail_result


### PR DESCRIPTION
The whole `/var/lib` is not needed by the compile sandbox, so we mount `/var/lib/ghc` instead and only do it for HASKELL.