### PR TITLE
Catch exceptions from malformed submission frames instead of crashing

### DIFF
--- a/src/server_io.cpp
+++ b/src/server_io.cpp
@@ -140,22 +140,29 @@ std::mutex judge_mtx;
 bool DealOneSubmission(nlohmann::json&& data);
 
 void OneSubmissionThread(nlohmann::json&& data) {
-  int submission_id = data["submission_id"].get<int>();
-  std::lock_guard lck(judge_mtx);
-  // optionally reject submission here
-  if (CurrentSubmissionQueueSize() >= kMaxQueue) {
-    SendStatus(submission_id, "queued");
-    return;
-  }
-  if (CurrentSubmissionQueueSize() + 1 < kMaxQueue) TryFetchSubmission();
-  bool success = false;
   try {
-    success = DealOneSubmission(std::move(data));
-  } catch (...) {
-  }
-  if (!success) {
-    // send JE
-    SendStatus(submission_id, VerdictToAbr(Verdict::JE));
+    const int submission_id = data.at("submission_id").get<int>();
+    std::lock_guard lck(judge_mtx);
+    if (CurrentSubmissionQueueSize() >= kMaxQueue) {
+      SendStatus(submission_id, "queued");
+      return;
+    }
+    if (CurrentSubmissionQueueSize() + 1 < kMaxQueue) {
+      TryFetchSubmission();
+    }
+    auto try_deal_submission = [&] {
+      try {
+        return DealOneSubmission(std::move(data));
+      } catch (...) {
+        return false;
+      }
+    };
+    if (!try_deal_submission()) {
+      SendStatus(submission_id, VerdictToAbr(Verdict::JE));
+      TryFetchSubmission();
+    }
+  } catch (const nlohmann::json::exception& err) {
+    spdlog::warn("Submission parsing error: {}", err.what());
     TryFetchSubmission();
   }
 }


### PR DESCRIPTION
OneSubmissionThread previously accessed data["submission_id"].get<int>() at line 143 outside any try/catch, and ran in a detached std::thread. On a missing or wrong-typed submission_id, nlohmann::json::type_error was thrown uncaught in the thread, calling std::terminate per [thread.thread.con]/4 and aborting the whole judge daemon.

Hoist the entire function body into a single try/catch so any parse error gracefully returns without crashing. A malformed frame silently drops; the caller (OnMessage) continues normally.