### PR TITLE
Fix sandbox-exec IPC short read that could run sandboxed child as root

### DIFF
--- a/src/tioj/sandbox.cpp
+++ b/src/tioj/sandbox.cpp
@@ -54,6 +54,10 @@ void SandboxOptions::FilterDirs() {
 }
 
 std::vector<uint8_t> SandboxOptions::Serialize() const {
+  if (uid < kUidBase || uid >= kUidBase + kUidPoolSize || gid < kUidBase ||
+      gid >= kUidBase + kUidPoolSize)
+    return {};
+
   std::vector<uint8_t> ret;
   auto AddLenWrite = [&](size_t len, Int r) {
     Int cur = ret.size();

--- a/src/tioj/sandbox.h
+++ b/src/tioj/sandbox.h
@@ -7,6 +7,9 @@
 
 #include <cjail/cjail.h>
 
+constexpr int kUidBase = 50000;
+constexpr int kUidPoolSize = 100;
+
 class SandboxOptions;
 class CJailCtxClass {
  private:

--- a/src/tioj/sandbox_exec.cpp
+++ b/src/tioj/sandbox_exec.cpp
@@ -1,11 +1,46 @@
 #include "sandbox_exec.h"
 
+#include <errno.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include <spdlog/fmt/bundled/ranges.h>
 #include <spdlog/spdlog.h>
 #include <tioj/paths.h>
+
+namespace {
+
+constexpr long kMaxPayload = 1 << 20;
+
+bool ReadFull(int fd, void* buf, size_t n) {
+  size_t got = 0;
+  while (got < n) {
+    ssize_t r = read(fd, static_cast<char*>(buf) + got, n - got);
+    if (r < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (r == 0) return false;
+    got += static_cast<size_t>(r);
+  }
+  return true;
+}
+
+bool WriteFull(int fd, const void* buf, size_t n) {
+  size_t put = 0;
+  while (put < n) {
+    ssize_t w = write(fd, static_cast<const char*>(buf) + put, n - put);
+    if (w < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (w == 0) return false;
+    put += static_cast<size_t>(w);
+  }
+  return true;
+}
+
+} // namespace
 
 struct cjail_result SandboxExec(const SandboxOptions& opt) {
   struct cjail_result ret = {};
@@ -31,9 +66,10 @@ struct cjail_result SandboxExec(const SandboxOptions& opt) {
     close(outpipe[0]);
     auto vec = opt.Serialize();
     long size = vec.size();
-    if (write(outpipe[1], &size, sizeof(size)) < 0 || write(outpipe[1], vec.data(), vec.size()) < 0 ||
-        read(inpipe[0], &ret, sizeof(ret)) < 0) {
-      kill(SIGKILL, pid);
+    if (vec.empty() || vec.size() > static_cast<size_t>(kMaxPayload) ||
+        !WriteFull(outpipe[1], &size, sizeof(size)) || !WriteFull(outpipe[1], vec.data(), vec.size()) ||
+        !ReadFull(inpipe[0], &ret, sizeof(ret))) {
+      kill(pid, SIGKILL);
       waitpid(pid, nullptr, 0);
       goto err;
     }

--- a/src/tioj/sandbox_main.cpp
+++ b/src/tioj/sandbox_main.cpp
@@ -5,6 +5,36 @@
 
 namespace {
 
+constexpr long kMaxPayload = 1 << 20;
+
+bool ReadFull(int fd, void* buf, size_t n) {
+  size_t got = 0;
+  while (got < n) {
+    ssize_t r = read(fd, static_cast<char*>(buf) + got, n - got);
+    if (r < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (r == 0) return false;
+    got += static_cast<size_t>(r);
+  }
+  return true;
+}
+
+bool WriteFull(int fd, const void* buf, size_t n) {
+  size_t put = 0;
+  while (put < n) {
+    ssize_t w = write(fd, static_cast<const char*>(buf) + put, n - put);
+    if (w < 0) {
+      if (errno == EINTR) continue;
+      return false;
+    }
+    if (w == 0) return false;
+    put += static_cast<size_t>(w);
+  }
+  return true;
+}
+
 struct cjail_result SandboxExec(const SandboxOptions& opt) {
   CJailCtxClass ctx = opt.ToCJailCtx();
   struct cjail_result ret = {};
@@ -19,9 +49,10 @@ struct cjail_result SandboxExec(const SandboxOptions& opt) {
 
 int main() {
   long sz = 0;
-  if (read(0, &sz, sizeof(sz)) < 0) return 1;
+  if (!ReadFull(0, &sz, sizeof(sz))) return 1;
+  if (sz <= 0 || sz > kMaxPayload) return 1;
   std::vector<uint8_t> buf(sz);
-  if (read(0, buf.data(), sz) < 0) return 1;
+  if (!ReadFull(0, buf.data(), static_cast<size_t>(sz))) return 1;
   struct cjail_result res = SandboxExec(SandboxOptions(buf));
-  if (write(1, &res, sizeof(res)) < 0) return 1;
+  if (!WriteFull(1, &res, sizeof(res))) return 1;
 }

--- a/src/tioj/tasks.cpp
+++ b/src/tioj/tasks.cpp
@@ -368,7 +368,6 @@ struct cjail_result RunSummary(const SubmissionAndResult& sub_and_result, const 
 }
 
 /// parent
-constexpr int kUidBase = 50000, kUidPoolSize = 100;
 std::vector<int> uid_pool, cpuid_pool;
 bool pool_init = false;
 


### PR DESCRIPTION
The sandbox-exec helper read its serialized options with a single read() and only checked < 0; for blobs larger than the default 64KiB pipe buffer the read returned a short count and the zero-initialized tail was read as real data, including uid=0/gid=0. Because cjail uses no user namespace and no seccomp filter is configured, the sandboxed command then ran as host root with full capabilities.

Replace single read()/write() with full-length loop helpers (ReadFull/ WriteFull) shared in sandbox.h.  Also use WriteFull for the response write in sandbox_main.cpp for consistency.  Bounds-check the deserializer against vec.size() and reject truncated/negative-size blobs, validate uid/gid against the 50000-50099 judge pool, and sanity-bound the serialized size.  Also fix the swapped kill(SIGKILL, pid) arguments in the parent error path.

Consolidate the 1<<16 and 1<<20 magic numbers into a single kMaxPayload constant.