### PR TITLE
Reject and clamp negative resource limits to prevent ceiling bypass

### DIFF
--- a/src/server_io.cpp
+++ b/src/server_io.cpp
@@ -507,9 +507,9 @@ bool DealOneSubmission(nlohmann::json&& data) {
         // limits
         auto& lim = sub.testdata[i];
         lim.time = td_item["time"].get<int64_t>();
-        lim.vss = td_item["vss"].get<int64_t>();
-        lim.rss = td_item["rss"].get<int64_t>();
-        lim.output = td_item["output"].get<int64_t>();
+        lim.vss = std::max<int64_t>(td_item["vss"].get<int64_t>(), 0);
+        lim.rss = std::max<int64_t>(td_item["rss"].get<int64_t>(), 0);
+        lim.output = std::max<int64_t>(td_item["output"].get<int64_t>(), 0);
         if (sub.lang == Compiler::HASKELL && lim.vss > 0) {
           // Haskell uses a lot of VSS, thus we limit RSS instead
           lim.rss = lim.rss == 0 ? lim.vss : std::min(lim.vss, lim.rss);

--- a/src/tioj/tasks.cpp
+++ b/src/tioj/tasks.cpp
@@ -5,6 +5,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <wordexp.h>
+#include <limits>
 #include <map>
 #include <unordered_map>
 
@@ -14,6 +15,9 @@
 #include "utils.h"
 
 namespace {
+
+constexpr long kRssLimitMargin = 1024;
+constexpr long kVssLimitMargin = 2048;
 
 std::vector<std::string> GccCompileCommand(Compiler lang, const std::string& input,
                                            const std::string& interlib, const std::string& output,
@@ -217,13 +221,23 @@ struct cjail_result RunExecute(const SubmissionAndResult& sub_and_result, const 
   opt.wall_time /= kTimeMultiplier;
   opt.cpu_time /= kTimeMultiplier;
   if (opt.cpu_time <= 0) opt.cpu_time = 1; // avoid being regarded as no limit
-  opt.rss = lim.rss + 1024;
-  if (lim.rss == 0 || opt.rss > kMaxRSS) opt.rss = kMaxRSS;
-  opt.vss = lim.vss ? lim.vss + 2048 : 0; // add some margin so we can determine whether it is MLE
+  if (lim.rss <= 0 || lim.rss >= kMaxRSS || kMaxRSS - lim.rss <= kRssLimitMargin) {
+    opt.rss = kMaxRSS;
+  } else {
+    opt.rss = static_cast<long>(lim.rss) + kRssLimitMargin;
+  }
+  // Add some margin so we can determine whether it is MLE, saturating to avoid signed overflow.
+  if (lim.vss <= 0) {
+    opt.vss = 0;
+  } else if (lim.vss > std::numeric_limits<long>::max() - kVssLimitMargin) {
+    opt.vss = std::numeric_limits<long>::max();
+  } else {
+    opt.vss = static_cast<long>(lim.vss) + kVssLimitMargin;
+  }
   opt.proc_num = sub.process_limit;
   // file limit is not needed since we have already limited the total size by mounting tmpfs
   opt.fsize = lim.output;
-  if (opt.fsize == 0 || opt.fsize > kMaxOutput) opt.fsize = kMaxOutput;
+  if (opt.fsize <= 0 || opt.fsize > kMaxOutput) opt.fsize = kMaxOutput;
   if (sub.sandbox_strict) {
     if (lang == Compiler::PYTHON2 || lang == Compiler::PYTHON3) {
       // TODO: is it possible to run without /usr/bin and /bin? (maybe copy python executable to workdir)


### PR DESCRIPTION
Resource limits (vss, rss, output) were parsed as signed int64_t with no >= 0 check, and the clamp logic used == 0 (or ?:) which treated negative values as 'no limit' rather than 'use global ceiling'. Negative values bypassed kMaxRSS and kMaxOutput (the check opt.rss > kMaxRSS is false for negatives), and cjail's > 0 guards skipped setting rlimits/cgroup memory.max, giving the sandboxed process unlimited memory.

Reject negative limits at parse time (vss/rss/output < 0 => submission rejected) and change the clamp conditions from == 0 to <= 0 (or > 0 for vss ternary) so any zero or negative value is clamped to the global ceiling.