### PR TITLE
Catch std::thread creation failure to prevent judge crash

### DIFF
--- a/src/server_io.cpp
+++ b/src/server_io.cpp
@@ -4,6 +4,7 @@
 #include <condition_variable>
 #include <list>
 #include <mutex>
+#include <system_error>
 
 #include <httplib.h>
 #include <spdlog/fmt/bundled/core.h>
@@ -245,7 +246,11 @@ class TIOJClient : public WsClient {
     if (msg_type == "notify") {
       TryFetchSubmission();
     } else if (msg_type == "submission") {
-      std::thread(OneSubmissionThread, std::move(data["message"]["data"])).detach();
+      try {
+        std::thread(OneSubmissionThread, std::move(data["message"]["data"])).detach();
+      } catch (const std::system_error&) {
+        spdlog::warn("Dropping submission frame: thread limit reached");
+      }
     }
   }
 


### PR DESCRIPTION
OnMessage previously spawned a detached std::thread per submission frame outside any try/catch. Under a burst of frames the std::thread constructor could throw std::system_error (EAGAIN from pthread_create) when thread limits were exhausted; because the throw happened in the websocketpp I/O worker thread and was uncaught, std::terminate -> abort killed the whole judge daemon.

Wrap the std::thread construction in a try/catch for std::system_error that logs and drops the frame gracefully instead.